### PR TITLE
#New version: LocalRegistrator v0.2.2

### DIFF
--- a/L/LocalRegistrator/Versions.toml
+++ b/L/LocalRegistrator/Versions.toml
@@ -6,3 +6,6 @@ git-tree-sha1 = "007a2f71d75a0afa76af83ebcc651ffe6193ffbe"
 
 ["0.2.1"]
 git-tree-sha1 = "b68d34b55b7cce9e746cf2e23348b9beaeb53d15"
+
+["0.2.2"]
+git-tree-sha1 = "492f55154d40421c71bac80e03872f29dd2d2195"


### PR DESCRIPTION
- UUID: b2e007fe-26bf-4abf-a2e9-4b2a1ab78b25
- Repository: https://github.com/SuiteSplines/LocalRegistrator.jl.git
- Tree: 492f55154d40421c71bac80e03872f29dd2d2195
- Commit: 8e62d2dbf2e7c4c37e7846dfa1668686a4eff3d9
- Version: v0.2.2
- Labels: patch release