### PR TITLE
New version: LocalRegistrator v0.2.3

### DIFF
--- a/L/LocalRegistrator/Versions.toml
+++ b/L/LocalRegistrator/Versions.toml
@@ -9,3 +9,6 @@ git-tree-sha1 = "b68d34b55b7cce9e746cf2e23348b9beaeb53d15"
 
 ["0.2.2"]
 git-tree-sha1 = "492f55154d40421c71bac80e03872f29dd2d2195"
+
+["0.2.3"]
+git-tree-sha1 = "872060f69d95472d78de52c51a94d7cd3dbc34b9"


### PR DESCRIPTION
- UUID: b2e007fe-26bf-4abf-a2e9-4b2a1ab78b25
- Repository: https://github.com/SuiteSplines/LocalRegistrator.jl.git
- Tree: 872060f69d95472d78de52c51a94d7cd3dbc34b9
- Commit: 728bc976c30866f7a9d7043128dd03473c8e9adf
- Version: v0.2.3
- Labels: patch release