### PR TITLE
New package: TensorProductBsplines v0.8.2

### DIFF
--- a/Registry.toml
+++ b/Registry.toml
@@ -9,6 +9,7 @@ description = "SuiteSplines local registry"
 5766f8de-d509-470a-8420-f491b24ab91b = { name = "KroneckerProducts", path = "K/KroneckerProducts" }
 6606482d-3ef5-47b1-bd38-b02eeb053191 = { name = "SuiteSplinesExampleDep", path = "S/SuiteSplinesExampleDep" }
 7dac2afd-1bf6-47b8-bc94-9dcdcd19d527 = { name = "AbstractMappings", path = "A/AbstractMappings" }
+89f2e70f-f704-4f07-9b81-69bdc44074b1 = { name = "TensorProductBsplines", path = "T/TensorProductBsplines" }
 9c103fa8-ae55-49f5-92db-ab77803cf2c4 = { name = "IgaBase", path = "I/IgaBase" }
 b2e007fe-26bf-4abf-a2e9-4b2a1ab78b25 = { name = "LocalRegistrator", path = "L/LocalRegistrator" }
 ddfd9c64-15e7-45fc-8e16-950f3835cae5 = { name = "CartesianProducts", path = "C/CartesianProducts" }

--- a/T/TensorProductBsplines/Compat.toml
+++ b/T/TensorProductBsplines/Compat.toml
@@ -1,0 +1,7 @@
+[0]
+AbstractMappings = "0.8.1-0.8"
+CartesianProducts = "0.15"
+IgaBase = "0.8"
+KroneckerProducts = "0.13"
+SortedSequences = "0.6.2-0.6"
+UnivariateSplines = "0.14"

--- a/T/TensorProductBsplines/Deps.toml
+++ b/T/TensorProductBsplines/Deps.toml
@@ -1,0 +1,9 @@
+[0]
+AbstractMappings = "7dac2afd-1bf6-47b8-bc94-9dcdcd19d527"
+CartesianProducts = "ddfd9c64-15e7-45fc-8e16-950f3835cae5"
+IgaBase = "9c103fa8-ae55-49f5-92db-ab77803cf2c4"
+KroneckerProducts = "5766f8de-d509-470a-8420-f491b24ab91b"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+SortedSequences = "2f2e3dc8-c2cf-4b7f-b456-36845a1cbdbc"
+UnivariateSplines = "2552f6ce-f0d6-4ba3-bf39-bb338613ee69"

--- a/T/TensorProductBsplines/Package.toml
+++ b/T/TensorProductBsplines/Package.toml
@@ -1,0 +1,3 @@
+name = "TensorProductBsplines"
+uuid = "89f2e70f-f704-4f07-9b81-69bdc44074b1"
+repo = "https://github.com/SuiteSplines/TensorProductBsplines.jl.git"

--- a/T/TensorProductBsplines/Versions.toml
+++ b/T/TensorProductBsplines/Versions.toml
@@ -1,0 +1,2 @@
+["0.8.2"]
+git-tree-sha1 = "e08eb96588cf5564de86c50ab7aff38531f977a8"


### PR DESCRIPTION
- UUID: 89f2e70f-f704-4f07-9b81-69bdc44074b1
- Repository: https://github.com/SuiteSplines/TensorProductBsplines.jl.git
- Tree: e08eb96588cf5564de86c50ab7aff38531f977a8
- Commit: cbc6394b1bf876227814f3e9bcfa8adc5f95f9d8
- Version: v0.8.2
- Labels: new package