### PR TITLE
New version: CartesianProducts v0.15.1

### DIFF
--- a/C/CartesianProducts/Versions.toml
+++ b/C/CartesianProducts/Versions.toml
@@ -1,2 +1,5 @@
 ["0.15.0"]
 git-tree-sha1 = "67f70c77d6b9a3900ad20e2e6e402caa79e70cd3"
+
+["0.15.1"]
+git-tree-sha1 = "a459d4f6a7bf33ab97dea4bf4ed31f86e6f00f7b"


### PR DESCRIPTION
- UUID: ddfd9c64-15e7-45fc-8e16-950f3835cae5
- Repository: https://github.com/SuiteSplines/CartesianProducts.jl.git
- Tree: a459d4f6a7bf33ab97dea4bf4ed31f86e6f00f7b
- Commit: 89d73806963016d23ceff9f50bd5b3004137fc8e
- Version: v0.15.1
- Labels: patch release