### PR TITLE
New version: IgaBase v0.9.0

### DIFF
--- a/I/IgaBase/Versions.toml
+++ b/I/IgaBase/Versions.toml
@@ -1,2 +1,5 @@
 ["0.8.1"]
 git-tree-sha1 = "b4720c4b077812c93fb155c89c23a1c9adceb9f9"
+
+["0.9.0"]
+git-tree-sha1 = "8366549e40f6da15c3d4e31977e85517b7c1c905"


### PR DESCRIPTION
- UUID: 9c103fa8-ae55-49f5-92db-ab77803cf2c4
- Repository: https://github.com/SuiteSplines/IgaBase.jl.git
- Tree: 8366549e40f6da15c3d4e31977e85517b7c1c905
- Commit: f90977d40de7b0bfadd7f01175095318a134840a
- Version: v0.9.0
- Labels: minor release, BREAKING