### PR TITLE
New version: AbstractMappings v0.8.11

### DIFF
--- a/A/AbstractMappings/Compat.toml
+++ b/A/AbstractMappings/Compat.toml
@@ -1,9 +1,14 @@
 [0]
 CartesianProducts = "0.15"
 ForwardDiff = "1.0.1-1"
-IgaBase = "0.8"
 LRUCache = "1.6.2-1"
 RecipesBase = "1.3.4-1"
 SortedSequences = "0.6.2-0.6"
 StaticArrays = "1.9.13-1"
 julia = "1.10.0-1"
+
+["0-0.8.10"]
+IgaBase = "0.8"
+
+["0.8.11-0"]
+IgaBase = "0.8-0.9"

--- a/A/AbstractMappings/Versions.toml
+++ b/A/AbstractMappings/Versions.toml
@@ -1,2 +1,5 @@
 ["0.8.10"]
 git-tree-sha1 = "724cb341da368cbe1b5a238dd2672309b56122df"
+
+["0.8.11"]
+git-tree-sha1 = "97d8fe52004333f796975280c109b5bb86dbc8db"


### PR DESCRIPTION
- UUID: 7dac2afd-1bf6-47b8-bc94-9dcdcd19d527
- Repository: https://github.com/SuiteSplines/AbstractMappings.jl.git
- Tree: 97d8fe52004333f796975280c109b5bb86dbc8db
- Commit: 35cbfd65b8ad82fb732ec98bb60718b6460738ec
- Version: v0.8.11
- Labels: patch release