### PR TITLE
New version: TensorProductBsplines v0.8.3

### DIFF
--- a/T/TensorProductBsplines/Compat.toml
+++ b/T/TensorProductBsplines/Compat.toml
@@ -1,7 +1,13 @@
 [0]
 AbstractMappings = "0.8.1-0.8"
 CartesianProducts = "0.15"
-IgaBase = "0.8"
 KroneckerProducts = "0.13"
 SortedSequences = "0.6.2-0.6"
+
+["0-0.8.2"]
+IgaBase = "0.8"
 UnivariateSplines = "0.14"
+
+["0.8.3-0"]
+IgaBase = "0.9"
+UnivariateSplines = "0.15"

--- a/T/TensorProductBsplines/Versions.toml
+++ b/T/TensorProductBsplines/Versions.toml
@@ -1,2 +1,5 @@
 ["0.8.2"]
 git-tree-sha1 = "e08eb96588cf5564de86c50ab7aff38531f977a8"
+
+["0.8.3"]
+git-tree-sha1 = "03a3f4f41212ec34bf64109ec9c5abe75ee4798d"


### PR DESCRIPTION
- UUID: 89f2e70f-f704-4f07-9b81-69bdc44074b1
- Repository: https://github.com/SuiteSplines/TensorProductBsplines.jl.git
- Tree: 03a3f4f41212ec34bf64109ec9c5abe75ee4798d
- Commit: a40357e394a2b630e5c3ac2f39cdf5a297bcef88
- Version: v0.8.3
- Labels: patch release