### PR TITLE
New version: NURBS v0.12.1

### DIFF
--- a/N/NURBS/Compat.toml
+++ b/N/NURBS/Compat.toml
@@ -1,8 +1,15 @@
 [0]
 AbstractMappings = "0.8.2-0.8"
 CartesianProducts = "0.15"
-IgaBase = "0.8"
 KroneckerProducts = "0.13"
 SortedSequences = "0.6.2-0.6"
+
+["0-0.12.0"]
+IgaBase = "0.8"
 TensorProductBsplines = "0.8.2-0.8"
 UnivariateSplines = "0.14"
+
+["0.12.1-0"]
+IgaBase = "0.9"
+TensorProductBsplines = "0.8.3-0.8"
+UnivariateSplines = "0.15"

--- a/N/NURBS/Versions.toml
+++ b/N/NURBS/Versions.toml
@@ -1,2 +1,5 @@
 ["0.12.0"]
 git-tree-sha1 = "00cded85220bc12949711e0050baa057b28b3929"
+
+["0.12.1"]
+git-tree-sha1 = "5f2ffdc9470c55de91ab604b2bae50da33a7b2fd"


### PR DESCRIPTION
- UUID: 3119edd0-0685-4064-9500-10252e0e5727
- Repository: https://github.com/SuiteSplines/NURBS.jl.git
- Tree: 5f2ffdc9470c55de91ab604b2bae50da33a7b2fd
- Commit: c2aa408e2c8c11561cdd0527f1163b423bb090df
- Version: v0.12.1
- Labels: patch release