### PR TITLE
New version: BezierBernsteinMethods v0.2.2

### DIFF
--- a/B/BezierBernsteinMethods/Compat.toml
+++ b/B/BezierBernsteinMethods/Compat.toml
@@ -1,0 +1,6 @@
+["0.2.2-0"]
+Combinatorics = "1.0.3-1"
+IgaBase = "0.9"
+SparseArrays = "1.10.0-1"
+StaticArrays = "1.9.13-1"
+julia = "1.10.0-1"

--- a/B/BezierBernsteinMethods/Deps.toml
+++ b/B/BezierBernsteinMethods/Deps.toml
@@ -3,3 +3,6 @@ Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+["0.2.2-0"]
+IgaBase = "9c103fa8-ae55-49f5-92db-ab77803cf2c4"

--- a/B/BezierBernsteinMethods/Versions.toml
+++ b/B/BezierBernsteinMethods/Versions.toml
@@ -1,2 +1,5 @@
 ["0.2.1"]
 git-tree-sha1 = "7a61acf5d5f1fdfe9b5080098417818876831280"
+
+["0.2.2"]
+git-tree-sha1 = "52ee9fe2ee42ccbfd71a6c39fb888e15827a2422"


### PR DESCRIPTION
- UUID: e2515d83-272f-46f3-a47f-6d1ac1d67685
- Repository: https://github.com/SuiteSplines/BezierBernsteinMethods.jl.git
- Tree: 52ee9fe2ee42ccbfd71a6c39fb888e15827a2422
- Commit: e31bebbc8a951cbfd21006508fc6f759c3c13161
- Version: v0.2.2
- Labels: patch release